### PR TITLE
feat(core): support creature path

### DIFF
--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -7,6 +7,7 @@
     "ctypes",
     "ebnf",
     "expl",
+    "falmer",
     "fullscreen",
     "Geoffroy",
     "Greatsword",


### PR DESCRIPTION


# New Features

- [x] Until now, if I had specified an output destination for OAR, it would have been forced to be created in `character`. This has been changed, and other actors will be handled by inferring from the path. If it is impossible, fall back to `character`.