### PR TITLE
Fixes for compiling with Nix

### DIFF
--- a/gui/backend/Cargo.toml
+++ b/gui/backend/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1.20.1"
 serde = { workspace = true, features = ["derive"] }         # Implement (De)Serializer
 serde_json = { workspace = true }                           # To avoid generate_context error.
 snafu = { workspace = true }                                # Implement error types
-tauri = { version = "2.0.1", features = ["devtools"] }      # For GUI
+tauri = { version = "2.0.1", features = ["devtools", "native-tls"] }      # For GUI
 tauri-plugin-dialog = "2.0.1"                               # https://github.com/tauri-apps/plugins-workspace
 tauri-plugin-fs = "2.0.1"
 tauri-plugin-shell = "2.0.1"

--- a/gui/frontend/src/app/globals.css
+++ b/gui/frontend/src/app/globals.css
@@ -18,6 +18,7 @@
 
 html,
 body {
+  font-family: 'Inter', sans-serif;
   max-width: 100vw;
   min-height: 100vh;
   overflow-x: hidden;

--- a/gui/frontend/src/app/layout.tsx
+++ b/gui/frontend/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import dynamic from 'next/dynamic';
 
 export { metadata } from '@/components/meta/meta';
-import { inter } from '@/components/meta/font';
 import Loading from '@/components/templates/Loading';
+import '@fontsource/inter'
 
 import type { ReactNode } from 'react';
 
@@ -19,7 +19,7 @@ type Props = Readonly<{
 export default function RootLayout({ children }: Props) {
   return (
     <html lang='en'>
-      <body className={inter.className}>
+      <body>
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>

--- a/gui/frontend/src/components/meta/font.ts
+++ b/gui/frontend/src/components/meta/font.ts
@@ -1,3 +1,0 @@
-import { Inter } from 'next/font/google';
-
-export const inter = Inter({ subsets: ['latin'] });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@fontsource/inter": "^5.1.0",
         "@monaco-editor/react": "^4.6.0",
         "@mui/icons-material": "6.1.4",
         "@mui/lab": "6.0.0-beta.12",
@@ -997,6 +998,12 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
       "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.1.0.tgz",
+      "integrity": "sha512-zKZR3kf1G0noIes1frLfOHP5EXVVm0M7sV/l9f/AaYf+M/DId35FO4LkigWjqWYjTJZGgplhdv4cB+ssvCqr5A==",
+      "license": "OFL-1.1"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@fontsource/inter": "^5.1.0",
     "@monaco-editor/react": "^4.6.0",
     "@mui/icons-material": "6.1.4",
     "@mui/lab": "6.0.0-beta.12",


### PR DESCRIPTION
I'm attempting to package this for Nix, and since Nix can't access the internet while building, the font needs to be included as a dependency, I also made Tauri use the native SSL library so I didn't have to add the `hyper-tls` dependency.
